### PR TITLE
Foss

### DIFF
--- a/task-01/data.txt
+++ b/task-01/data.txt
@@ -1,7 +1,7 @@
 OpenCode FOSS Wing – Merge Conflict Task
 
 Learning real-world Git workflows.
-This line is modified in Branch A.
+This line is modified in Branch A and Branch B.
 Git conflicts are normal in open source.
 I am learning how to resolve them properly.
 


### PR DESCRIPTION
 Issue : #31 
 Difference between git commit -m and git commit -am

git commit -m is used to commit only those files that have already been staged using git add.
On the other hand, git commit -am automatically stages and commits files that are already being tracked by git. However, it does not include any new files.

Main cause of the merge conflict

The merge conflict occurred because the same line in the same file was modified differently in two separate branches. Since git could not automatically determine which version was correct, manual intervention was required to resolve the conflict by combining both changes.
<img width="966" height="196" alt="Screenshot 2025-12-28 002731" src="https://github.com/user-attachments/assets/9d29a783-dd91-4b1b-8fb9-d24829d7d118" />
