### PR TITLE
Updated amend.txt using commit amend

### DIFF
--- a/tasks/task-02/LooninS/amend.txt
+++ b/tasks/task-02/LooninS/amend.txt
@@ -1,0 +1,1 @@
+Git amend practice.


### PR DESCRIPTION
Issue: #44 
<img width="804" height="627" alt="t2s" src="https://github.com/user-attachments/assets/a973d074-f020-4eb7-b12e-a285524755d5" />

### `After commit --amend`
<img width="862" height="634" alt="t2s2" src="https://github.com/user-attachments/assets/00f3b446-ffce-4cfd-8ef3-8f41f9121ef7" />

## Q/A
- Why does Git still show only one commit after using git commit --amend?
`git commit --amend` replaces the most recent commit with a new one that has the same parent, so Git history shows only one commit instead of two.  This doesn't edit the commit, as we can see the SHA before and after the `--amend` are different , rather it discard the original commit and generate a new commit.

- What is the risk of using git commit --amend after pushing the commit?
Amending a pushed commit rewrites its hash, causing your local history to diverge from the remote. This leads to push rejections as non-fast-forward updates.