### PR TITLE
Updated amend.txt using commit amend

### DIFF
--- a/tasks/task-02/icyfire8/amend.txt
+++ b/tasks/task-02/icyfire8/amend.txt
@@ -1,0 +1,1 @@
+Git amend practice.


### PR DESCRIPTION
Issue: #44 

Before amend:
<img width="1920" height="1080" alt="Screenshot (69)" src="https://github.com/user-attachments/assets/4a9b65d3-e482-4efb-97c8-cfded66d0885" />

After amend:
<img width="713" height="436" alt="Screenshot 2025-12-31 133909" src="https://github.com/user-attachments/assets/80145c13-7f81-4a7f-8fad-812b93237975" />

Q1: Why does Git still show only one commit after using git commit --amend?

The --amend command overwrites the previous commit keeping the commit count same.

Q2: What is the risk of using git commit --amend after pushing the commit?

When the old commit is overwritten using git commit --amend, the code in remote repository changes. If other people have already pulled the original commit, their local history will no longer match the remote branch, leading to merge conflicts.